### PR TITLE
Update Dependabot schedule and add GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,14 @@ updates:
     target-branch: "main"
     open-pull-requests-limit: 20
     schedule:
-      interval: "daily"
-      time: "08:00"
+      interval: "weekly"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "develop"
+    open-pull-requests-limit: 20
+    schedule:
+      interval: "weekly"
+      time: "09:00"
       timezone: "Asia/Tokyo"


### PR DESCRIPTION
Changed the schedule for dependency updates to weekly and added GitHub Actions as a package ecosystem.